### PR TITLE
feat: individual news details pages

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>News</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="description"
+      content="AGenCy Lab, Independent University Bangladesh"
+    />
+    <meta name="author" content="" />
+    <!-- Le styles -->
+    <link href="css/bootstrap.min.css" rel="stylesheet" />
+    <link href="css/bootstrap-responsive.min.css" rel="stylesheet" />
+    <link href="css/theme.css" rel="stylesheet" />
+    <script src="js/jquery-1.9.1.min.js"></script>
+    <script>
+      $(function () {
+        $("#header").load("header.html");
+        $("#footer").load("footer.html");
+      });
+    </script>
+  </head>
+
+  <body>
+    <script src="js/web-components/NavBar.js"></script>
+    <div id="header"></div>
+    <nav-bar></nav-bar>
+
+    <div class="container">
+      <div class="page-404-inner-container">
+        <h1>Route Not Found</h1>
+        <h4>
+          Sorry, but the information/page that you were looking for does not
+          exist (yet).
+        </h4>
+        <a href="/">Take me to homepage</a>
+      </div>
+    </div>
+
+    <div id="footer"></div>
+    <!-- <script src="js/jquery-1.9.1.min.js"></script> -->
+    <script src="js/bootstrap.min.js"></script>
+  </body>
+</html>

--- a/css/news-details-style.css
+++ b/css/news-details-style.css
@@ -1,0 +1,58 @@
+.news-container {
+  padding-bottom: 24px;
+}
+
+.news-image-container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+}
+
+.news-image {
+  width: auto;
+  height: 50vh;
+  object-fit: cover;
+  margin-bottom: 16px;
+}
+
+.news-image-caption {
+  font-weight: bold;
+  font-size: 1.2em;
+}
+
+.news-body {
+  margin-top: 16px;
+  font-size: 1.3em;
+}
+
+.news-date-container {
+  display: flex;
+  align-items: center;
+  margin: 8px 0;
+}
+
+.news-date-container p {
+  margin: 0;
+  padding: 0;
+  font-weight: bold;
+  font-size: 1.3em;
+}
+
+.news-date-container i {
+  font-size: 1.3em;
+  padding: 0 8px 0 0;
+}
+
+.copy-news-link-button {
+  background-color: #2e2e2e;
+  color: #eee;
+  padding: 8px 16px;
+  border-radius: 2em;
+}
+
+.copy-news-link-button:disabled,
+.copy-news-link-button[disabled="disabled"] {
+  background-color: rgb(0, 156, 60);
+  color: #fff;
+}

--- a/css/theme.css
+++ b/css/theme.css
@@ -989,3 +989,19 @@ ul.sponsors {
   max-height: 60vh;
   object-fit: cover;
 }
+
+.page-404-inner-container {
+  padding: 16px 0;
+  min-height: 50vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+}
+
+.page-404-inner-container a {
+  font-size: 1.5em;
+  margin: unset;
+  padding: unset;
+  padding: 16px 0;
+}

--- a/data/news.json
+++ b/data/news.json
@@ -1,46 +1,46 @@
 {
   "news": [
     {
+      "id": "rehab-team-visits-crp",
       "date": "25/05/2021",
       "title": "Rehab team visits CRP",
-      "description": "Our Rehab team has a successful meeting with the CRP physiotherapy team at Savar, Dhaka. Rehab team has shown demonstration for wearable sensors and  Kinect sensors to track limb movements",
-      "image": "images/news/crp.png",
-      "link": "news.html"
+      "description": "Our Rehab team has a successful meeting with the Centre for the Rehabilitation of the Paralysed (CRP) physiotherapy team at Savar, Dhaka. Rehab team has shown demonstration for wearable sensors and Kinect sensors to track limb movements",
+      "image": "images/news/crp.png"
     },
     {
+      "id": "paper-accepted-at-ieee-icip-2021-attention-toward-neighbors",
       "date": "20/05/2021",
       "title": "Paper accepted at IEEE ICIP 2021",
       "description": "Our paper 'Attention Toward Neighbors: A Context Aware Framework for High Resolution Image Segmentation', has been accepted in IEEE ICIP 2021. Congratulations to Niloy.",
-      "image": "images/news/icip2021.png",
-      "link": "news.html"
+      "image": "images/news/icip2021.png"
     },
     {
+      "id": "presentation-on-semi-supervised-variational-inference",
       "date": "17/04/2021",
       "title": "Presentation on semi-supervised variational interface",
       "description": "We have an online presentation and discussion on semi-supervised variational inference at 22:30 through Google Meet platform.",
-      "image": "images/news/semi-vae.png",
-      "link": "news.html"
+      "image": "images/news/semi-vae.png"
     },
     {
+      "id": "paper-accepted-at-ijcnn-2021-structure-aware-hierarchical",
       "date": "10/04/2021",
       "title": "Paper accepted at IJCNN 2021",
       "description": "Our paper 'Structure-Aware Hierarchical Graph Pooling using Information Bottleneck', has been accepted in IJCNN 2021 (Core Rank: A). Congratulations to Kashob and Amit.",
-      "image": "images/news/ijcnn2021.png",
-      "link": "news.html"
+      "image": "images/news/ijcnn2021.png"
     },
     {
+      "id": "paper-accepted-at-ijcnn-2021-node-embedding-using-mutual-information",
       "date": "10/04/2021",
       "title": "Paper accepted at IJCNN 2021",
       "description": "Our paper 'Node Embedding using Mutual Information and Self-Supervision based Bi-level Aggregation', has been accepted in IJCNN 2021 (Core Rank: A). Congratulations to Kashob and Amit.",
-      "image": "images/news/ijcnn2021.png",
-      "link": "news.html"
+      "image": "images/news/ijcnn2021.png"
     },
     {
+      "id": "paper-accepted-at-pakdd-2021-hierarchical-self-attention",
       "date": "09/02/2021",
       "title": "Paper accepted at PAKDD 2021",
       "description": "Our Human Activity Recognition paper 'Hierarchical Self Attention Based Autoencoder for Open-Set Human Activity Recognition', has been accepted in PAKDD 2021 (Core Rank: A). Congratulations to Saif and Tanjid.",
-      "image": "images/news/pakdd2021.png",
-      "link": "news.html"
+      "image": "images/news/pakdd2021.png"
     },
     {
       "date": "10/04/2021",

--- a/js/load-news-details.js
+++ b/js/load-news-details.js
@@ -1,0 +1,47 @@
+function loadNewsDetails() {
+  let newsId = document.location.hash;
+
+  if (!Boolean(newsId)) {
+    window.location.href = "404.html";
+    return;
+  }
+
+  newsId = newsId.slice(1); // discard the # itself
+
+  fetch("/data/news.json")
+    .then((response) => response.json())
+    .then(({ news }) => {
+      // find out the news with id fields
+      const newsWithIds = news.filter((news) => typeof news.id !== "undefined");
+      const newsWithCurrentIdArray = newsWithIds.filter(
+        (news) => news.id === newsId
+      );
+
+      if (newsWithCurrentIdArray.length !== 1) {
+        window.location.href = "404.html";
+        return;
+      }
+
+      const currentNewsDetails = newsWithCurrentIdArray[0];
+
+      const newsDetailsElement = `
+        <news-details
+          title="${currentNewsDetails.title}"
+          date="${formatDate(currentNewsDetails.date)}"
+          image="${currentNewsDetails.image}"
+          image-caption="${currentNewsDetails.title}"
+          description="${currentNewsDetails.description}"
+        >
+        </news-details>
+      `;
+
+      document
+        .querySelector(".row-fluid")
+        .insertAdjacentHTML("beforeend", newsDetailsElement);
+    })
+    .catch((error) => console.error(error)); // TODO: error page
+
+  console.log(document.location);
+}
+
+loadNewsDetails();

--- a/js/load-news.js
+++ b/js/load-news.js
@@ -21,13 +21,13 @@ function loadNews() {
       );
       const otherNewsTargetDiv = document.querySelector("#other_news_content");
 
-      featuredNews.forEach(({ date, description, image, link, title }) => {
+      featuredNews.forEach(({ date, description, image, id, title }) => {
         const html = `<featured-news
                       date="${formatDate(date)}"
                       title="${title}"
                       description="${description}"
                       image=${image}
-                      link=${link}
+                      link="/news-details.html#${id}"
                     >
                     </featured-news>
       `;

--- a/js/web-components/NewsDetails.js
+++ b/js/web-components/NewsDetails.js
@@ -1,0 +1,100 @@
+const newsDetailsTemplate = document.createElement("template");
+newsDetailsTemplate.innerHTML = `
+  <link href="/css/theme.css" rel="stylesheet" />
+  <link href="/css/news-details-style.css" rel="stylesheet" />
+  <link
+      rel="stylesheet"
+      href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css"
+      integrity="sha512-SfTiTlX6kk+qitfevl/7LibUOeJWlt9rbyDn92a1DqWOw9vWG2MFoays0sgObmWazO5BQPiFucnnEAjpAB+/Sw=="
+      crossorigin="anonymous"
+      referrerpolicy="no-referrer"
+  ></link>
+
+  <div class="news-container">
+    <h1 class="news-title"></h1>
+    <div class="news-date-container">
+      <i class="fa fa-calendar-o" aria-hidden="true"></i>
+      <p class="news-date"></p>
+    </div>
+    <button class="copy-news-link-button">Share News Link</button>
+    <div class="news-image-container">
+      <img class="news-image" src="" />
+      <em class="news-image-caption"></em>
+    </div>
+    <div class="news-body"></div>
+  </div>
+`;
+
+class NewsDetails extends HTMLElement {
+  constructor() {
+    super();
+    this.attachShadow({ mode: "open" });
+    this.shadowRoot.appendChild(newsDetailsTemplate.content.cloneNode(true));
+  }
+
+  setNewsTitle(title) {
+    if (title) {
+      this.shadowRoot.querySelector(".news-title").innerHTML = title;
+    }
+  }
+
+  setNewsDate(date) {
+    if (date) {
+      this.shadowRoot
+        .querySelector(".news-date")
+        .insertAdjacentText("beforeend", date);
+    }
+  }
+
+  setNewsImage(imageSrc) {
+    if (imageSrc) {
+      this.shadowRoot.querySelector(".news-image").src = imageSrc;
+    }
+  }
+
+  setNewsImageCaption(imageCaption) {
+    if (imageCaption) {
+      this.shadowRoot.querySelector(".news-image-caption").innerHTML =
+        imageCaption;
+    }
+  }
+
+  setNewsDescription(description) {
+    if (description) {
+      this.shadowRoot.querySelector(".news-body").innerHTML = description;
+    }
+  }
+
+  connectedCallback() {
+    const newsTitle = this.getAttribute("title");
+    const newsDate = this.getAttribute("date");
+    const newsImageSrc = this.getAttribute("image");
+    const newsImageCaption = this.getAttribute("image-caption");
+    const newsDescription = this.getAttribute("description");
+
+    this.setNewsTitle(newsTitle);
+    this.setNewsDate(newsDate);
+    this.setNewsImage(newsImageSrc);
+    this.setNewsImageCaption(newsImageCaption);
+    this.setNewsDescription(newsDescription);
+
+    const disabledDuration = 60 * 1000; // 60 seconds
+
+    const copyNewsLinkButton = this.shadowRoot.querySelector(
+      ".copy-news-link-button"
+    );
+
+    copyNewsLinkButton.addEventListener("click", function (event) {
+      navigator.clipboard.writeText(window.location.href);
+      copyNewsLinkButton.innerHTML = "Link Copied!";
+      copyNewsLinkButton.disabled = true;
+
+      setTimeout(() => {
+        copyNewsLinkButton.innerHTML = "Share News Link";
+        copyNewsLinkButton.disabled = false;
+      }, disabledDuration);
+    });
+  }
+}
+
+window.customElements.define("news-details", NewsDetails);

--- a/news-details.html
+++ b/news-details.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>News Details</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="description"
+      content="AGenCy Lab, Independent University Bangladesh"
+    />
+    <meta name="author" content="" />
+    <!-- Le styles -->
+    <link href="css/bootstrap.min.css" rel="stylesheet" />
+    <link href="css/bootstrap-responsive.min.css" rel="stylesheet" />
+    <link href="css/theme.css" rel="stylesheet" />
+
+    <link
+      rel="stylesheet"
+      href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css"
+      integrity="sha512-SfTiTlX6kk+qitfevl/7LibUOeJWlt9rbyDn92a1DqWOw9vWG2MFoays0sgObmWazO5BQPiFucnnEAjpAB+/Sw=="
+      crossorigin="anonymous"
+      referrerpolicy="no-referrer"
+    />
+    <script src="js/jquery-1.9.1.min.js"></script>
+    <script>
+      $(function () {
+        $("#header").load("header.html");
+        $("#footer").load("footer.html");
+      });
+    </script>
+  </head>
+
+  <body>
+    <script src="js/web-components/NavBar.js"></script>
+    <script src="js/web-components/NewsDetails.js"></script>
+
+    <div id="header"></div>
+    <nav-bar></nav-bar>
+
+    <div class="container">
+      <div class="row-fluid"></div>
+    </div>
+
+    <div id="footer"></div>
+    <!-- <script src="js/jquery-1.9.1.min.js"></script> -->
+    <script src="js/bootstrap.min.js"></script>
+
+    <!-- for date time parsing -->
+    <script
+      src="https://cdnjs.cloudflare.com/ajax/libs/luxon/2.1.1/luxon.min.js"
+      integrity="sha512-R3qVfQx4LUWixeZgtptH0NDb+/FB8qVflpPQUKzDQlz1zKE3BiN4wG3aBUwzabgMo/45MXHucjcC2/BWBxMJwQ=="
+      crossorigin="anonymous"
+      referrerpolicy="no-referrer"
+    ></script>
+
+    <!-- for date formatting -->
+    <script src="js/utils.js"></script>
+
+    <!-- for loading news details -->
+    <script src="js/load-news-details.js"></script>
+
+    <!-- for listening to changes to window hash -->
+    <script>
+      window.onhashchange = function () {
+        loadNewsDetails();
+      };
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
This is an implementation of separate news details pages without having to create a bazillion separate HTML pages.

Basic flow:
- The news.json file has an `id` field, the `id` field should be unique and should be formed using the title of the news
- The news links are created using hashes in `news-details.html`
- The JavaScript file finds the appropriate news from the json file using the hash and the `id` field and loads the news details or simply shows 404 page if no such news is found.